### PR TITLE
Only include necessary Bevy features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,11 @@ readme = "readme.md"
 repository = "https://github.com/FraserLee/bevy_sprite3d"
 keywords = ["gamedev", "bevy", "sprite", "3d"]
 
-[dependencies]
-bevy = "0.11"
+[dependencies.bevy]
+version = "0.11"
+default-features = false
+features = ["bevy_asset", "bevy_pbr", "bevy_sprite"]
 
 [dev-dependencies]
+bevy.version = "0.11" #(include default features when running examples)
 rand = "0.8"


### PR DESCRIPTION
Currently this crate is pulling in all of Bevy, preventing downstream consumers from excluding any of Bevy's default features.

This change trims the feature list to only those that are actually used in this crate.