### PR TITLE
Incorporate AtlasSprite rework for upcoming Bevy 1.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ repository = "https://github.com/FraserLee/bevy_sprite3d"
 keywords = ["gamedev", "bevy", "sprite", "3d"]
 
 [dependencies.bevy]
-# Switch back to "1.13" once that version comes out.
+# Switch to "0.13" once that version comes out.
 # I don't know if there's a better way to do this.
-# version = "0.12"
+# version = "0.13"
 git = "https://github.com/bevyengine/bevy.git"
 default-features = false
 features = ["bevy_asset", "bevy_pbr", "bevy_sprite"]
 
 [dev-dependencies]
-# bevy.version = "0.12" # (include default features when running examples)
+# bevy.version = "0.13" # (include default features when running examples)
 bevy = { git = "https://github.com/bevyengine/bevy.git" }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,10 @@ repository = "https://github.com/FraserLee/bevy_sprite3d"
 keywords = ["gamedev", "bevy", "sprite", "3d"]
 
 [dependencies.bevy]
-# Switch to "0.13" once that version comes out.
-# I don't know if there's a better way to do this.
-# version = "0.13"
-git = "https://github.com/bevyengine/bevy.git"
+version = "0.13"
 default-features = false
 features = ["bevy_asset", "bevy_pbr", "bevy_sprite"]
 
 [dev-dependencies]
-# bevy.version = "0.13" # (include default features when running examples)
-bevy = { git = "https://github.com/bevyengine/bevy.git" }
+bevy.version = "0.13" # (include default features when running examples)
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,14 @@ repository = "https://github.com/FraserLee/bevy_sprite3d"
 keywords = ["gamedev", "bevy", "sprite", "3d"]
 
 [dependencies.bevy]
-version = "0.12"
+# Switch back to "1.13" once that version comes out.
+# I don't know if there's a better way to do this.
+# version = "0.12"
+git = "https://github.com/bevyengine/bevy.git"
 default-features = false
 features = ["bevy_asset", "bevy_pbr", "bevy_sprite"]
 
 [dev-dependencies]
-bevy.version = "0.12" # (include default features when running examples)
+# bevy.version = "0.12" # (include default features when running examples)
+bevy = { git = "https://github.com/bevyengine/bevy.git" }
 rand = "0.8"

--- a/examples/dungeon.rs
+++ b/examples/dungeon.rs
@@ -98,16 +98,14 @@ fn setup(
 ) {
     // cube
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(Mesh::from(Cuboid::from_size(Vec3::splat(1.0)))),
         material: materials.add(Color::WHITE),
         transform: Transform::from_xyz(-0.9, 0.5, -3.1),
         ..default()
     });
     // sphere
     commands.spawn(PbrBundle {
-        mesh: meshes.add(
-            Mesh::try_from(shape::Icosphere { radius: 0.6, subdivisions: 20 }).unwrap()
-        ),
+        mesh: meshes.add(Sphere::new(0.6)),
         material: materials.add(Color::WHITE),
         transform: Transform::from_xyz(-0.9, 0.5, -4.2),
         ..default()

--- a/examples/dungeon.rs
+++ b/examples/dungeon.rs
@@ -1,7 +1,6 @@
 use bevy::{prelude::*, window::WindowResolution};
 use bevy::asset::LoadState;
 use bevy::core_pipeline::bloom::BloomSettings;
-use bevy::core_pipeline::clear_color::ClearColorConfig;
 use bevy::core_pipeline::tonemapping::Tonemapping;
 use bevy::render::camera::PerspectiveProjection;
 use bevy::utils::Duration;
@@ -26,7 +25,7 @@ enum GameState { #[default] Loading, Ready }
 #[derive(Resource, Default)]
 struct ImageAssets {
     image: Handle<Image>,
-    tileset: Handle<TextureAtlas>,
+    layout: Handle<TextureAtlasLayout>,
 }
 
 
@@ -43,17 +42,17 @@ fn main() {
             }))
         .insert_resource(Msaa::Off)
         .add_plugins(Sprite3dPlugin)
-        .add_state::<GameState>()
+        .init_state::<GameState>()
 
         // initially load assets
-        .add_systems(Startup, |asset_server:         Res<AssetServer>,
-                               mut assets:           ResMut<ImageAssets>,
-                               mut texture_atlases:  ResMut<Assets<TextureAtlas>>| {
+        .add_systems(Startup, |asset_server: Res<AssetServer>,
+                               mut assets:   ResMut<ImageAssets>,
+                               mut layouts:  ResMut<Assets<TextureAtlasLayout>>| {
 
             assets.image = asset_server.load("dungeon/tileset_padded.png");
 
-            assets.tileset = texture_atlases.add(
-                TextureAtlas::from_grid(assets.image.clone(),
+            assets.layout = layouts.add(
+                TextureAtlasLayout::from_grid(
                                         Vec2::new(16.0, 16.0),
                                         30,
                                         35,
@@ -63,7 +62,7 @@ fn main() {
         })
 
         // every frame check if assets are loaded. Once they are, we can proceed with setup.
-        .add_systems( Update, (
+        .add_systems(Update, (
                        |asset_server   : Res<AssetServer>,
                         assets         : Res<ImageAssets>,
                         mut next_state : ResMut<NextState<GameState>>| {
@@ -100,22 +99,24 @@ fn setup(
     // cube
     commands.spawn(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::WHITE.into()),
+        material: materials.add(Color::WHITE),
         transform: Transform::from_xyz(-0.9, 0.5, -3.1),
         ..default()
     });
     // sphere
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Icosphere { radius: 0.6, subdivisions: 20 }.try_into().unwrap()),
-        material: materials.add(Color::WHITE.into()),
+        mesh: meshes.add(
+            Mesh::try_from(shape::Icosphere { radius: 0.6, subdivisions: 20 }).unwrap()
+        ),
+        material: materials.add(Color::WHITE),
         transform: Transform::from_xyz(-0.9, 0.5, -4.2),
         ..default()
     });
 
     // camera
     commands.spawn((Camera3dBundle {
-            camera: Camera { hdr: true, ..default() },
-            camera_3d: Camera3d {
+            camera: Camera {
+                hdr: true,
                 clear_color: ClearColorConfig::Custom(Color::rgb(1.0, 1.0, 1.0) * 0.0),
                 ..default()
             },
@@ -211,14 +212,18 @@ fn spawn_sprites(
             let (x, y) = (x as f32 - map[y].len() as f32 / 2.0, y as f32 - map.len() as f32 / 2.0);
             if index == 0 { continue; }
 
-            commands.spawn(AtlasSprite3d {
-                    atlas: images.tileset.clone(),
+            let atlas = TextureAtlas {
+                layout: images.layout.clone(),
+                index: index as usize,
+            };
+
+            commands.spawn(Sprite3d {
+                    image: images.image.clone(),
                     pixels_per_metre: 16.,
-                    index: index as usize,
                     double_sided: false,
                     transform: Transform::from_xyz(x, 0.0, y).with_rotation(Quat::from_rotation_x(-std::f32::consts::PI / 2.0)),
                     ..default()
-            }.bundle(&mut sprite_params));
+            }.bundle_with_atlas(&mut sprite_params, atlas));
         }
     }
 
@@ -259,17 +264,21 @@ fn spawn_sprites(
 
             let (x, y) = (x as f32 - map[y].len() as f32 / 2.0, y as f32 - map.len() as f32 / 2.0);
 
-            for i in [0,1]{ // add bottom and top piece
-                commands.spawn(AtlasSprite3d {
-                        atlas: images.tileset.clone(),
+            for i in [0,1] { // add bottom and top piece
+                let atlas = TextureAtlas {
+                    layout: images.layout.clone(),
+                    index: (tile_x + (5 - i) * 30) as usize,
+                };
+                
+                commands.spawn(Sprite3d {
+                        image: images.image.clone(),
                         pixels_per_metre: 16.,
-                        index: (tile_x + (5 - i) * 30) as usize,
                         double_sided: false,
                         transform: Transform::from_xyz(x+0.5, i as f32 + 0.499, y)
                             .with_rotation(Quat::from_rotation_y(
                                 dir * std::f32::consts::PI / 2.0)),
                         ..default()
-                }.bundle(&mut sprite_params));
+                }.bundle_with_atlas(&mut sprite_params, atlas));
             }
         }
     }
@@ -293,16 +302,20 @@ fn spawn_sprites(
             let (x, y) = (x as f32 - map[y].len() as f32 / 2.0, y as f32 - map.len() as f32 / 2.0);
 
             for i in [0,1]{ // add bottom and top piece
-                commands.spawn(AtlasSprite3d {
-                        atlas: images.tileset.clone(),
+                let atlas = TextureAtlas {
+                    layout: images.layout.clone(),
+                    index: (tile_x + (5 - i) * 30) as usize,
+                };
+
+                commands.spawn(Sprite3d {
+                        image: images.image.clone(),
                         pixels_per_metre: 16.,
-                        index: (tile_x + (5 - i) * 30) as usize,
                         double_sided: false,
                         transform: Transform::from_xyz(x, i as f32 + 0.499, y + 0.5)
                             .with_rotation(Quat::from_rotation_y(
                                     (dir - 1.0) * std::f32::consts::PI / 2.0)),
                         ..default()
-                }.bundle(&mut sprite_params));
+                }.bundle_with_atlas(&mut sprite_params, atlas));
             }
         }
     }
@@ -314,13 +327,17 @@ fn spawn_sprites(
         timer.set_elapsed(Duration::from_secs_f32(rng.gen_range(0.0..0.4)));
 
         for i in 0usize..height {
-            let mut c = commands.spawn((AtlasSprite3d {
-                    atlas: images.tileset.clone(),
+            let atlas = TextureAtlas {
+                layout: images.layout.clone(),
+                index: (tile_x + (tile_y - i) * 30) as usize,
+            };
+
+            let mut c = commands.spawn((Sprite3d {
+                    image: images.image.clone(),
                     pixels_per_metre: 16.,
-                    index: (tile_x + (tile_y - i) * 30) as usize,
                     transform: Transform::from_xyz(x as f32, i as f32 + 0.498, y),
                     ..default()
-                }.bundle(&mut sprite_params),
+                }.bundle_with_atlas(&mut sprite_params, atlas),
                 FaceCamera {},
             ));
 
@@ -350,15 +367,19 @@ fn spawn_sprites(
     entity((4.2, -8.),  13, 16, 2, 1);
 
     // fire
-    commands.spawn((AtlasSprite3d {
-            atlas: images.tileset.clone(),
+    let atlas = TextureAtlas {
+        layout: images.layout.clone(),
+        index: 30*32 + 14,
+    };
+
+    commands.spawn((Sprite3d {
+            image: images.image.clone(),
             pixels_per_metre: 16.,
-            index: 30*32 + 14,
             transform: Transform::from_xyz(2.0, 0.5, -5.5),
             emissive: Color::rgb(1.0, 0.5, 0.0) * 10.0,
             unlit: true,
             ..default()
-        }.bundle(&mut sprite_params),
+        }.bundle_with_atlas(&mut sprite_params, atlas),
 
         Animation {
             frames: vec![30*32 + 14, 30*32 + 15, 30*32 + 16],
@@ -380,15 +401,19 @@ fn spawn_sprites(
     });
 
     // glowy book
-    commands.spawn((AtlasSprite3d {
-            atlas: images.tileset.clone(),
+    let atlas = TextureAtlas {
+        layout: images.layout.clone(),
+        index: 22*30 + 22,
+    };
+
+    commands.spawn((Sprite3d {
+            image: images.image.clone(),
             pixels_per_metre: 16.,
-            index: 22*30 + 22,
             transform: Transform::from_xyz(-5., 0.7, 6.5),
             emissive: Color::rgb(165./255., 1.0, 160./255.),
             unlit: true,
             ..default()
-        }.bundle(&mut sprite_params),
+        }.bundle_with_atlas(&mut sprite_params, atlas),
 
         FaceCamera {}
     ));
@@ -432,12 +457,12 @@ fn animate_camera(
 
 fn animate_sprites(
     time: Res<Time>,
-    mut query: Query<(&mut Animation, &mut AtlasSprite3dComponent)>,
+    mut query: Query<(&mut Animation, &mut TextureAtlas)>,
 ) {
-    for (mut animation, mut sprite) in query.iter_mut() {
+    for (mut animation, mut atlas) in query.iter_mut() {
         animation.timer.tick(time.delta());
         if animation.timer.just_finished() {
-            sprite.index = animation.frames[animation.current];
+            atlas.index = animation.frames[animation.current];
             animation.current += 1;
             animation.current %= animation.frames.len();
         }

--- a/examples/dungeon.rs
+++ b/examples/dungeon.rs
@@ -388,7 +388,7 @@ fn spawn_sprites(
     ));
     commands.spawn(PointLightBundle {
         point_light: PointLight {
-            intensity: 300.0,
+            intensity: 500_000.0,
             color: Color::rgb(1.0, 231./255., 221./255.),
             shadows_enabled: true,
             ..default()
@@ -416,7 +416,7 @@ fn spawn_sprites(
     ));
     commands.spawn(PointLightBundle {
         point_light: PointLight {
-            intensity: 100.0,
+            intensity: 70_000.0,
             color: Color::rgb(91./255., 1.0, 92./255.),
             shadows_enabled: true,
             ..default()

--- a/examples/dungeon.rs
+++ b/examples/dungeon.rs
@@ -2,7 +2,6 @@ use bevy::{prelude::*, window::WindowResolution};
 use bevy::asset::LoadState;
 use bevy::core_pipeline::bloom::BloomSettings;
 use bevy::core_pipeline::tonemapping::Tonemapping;
-use bevy::render::camera::PerspectiveProjection;
 use bevy::utils::Duration;
 use bevy::pbr::ScreenSpaceAmbientOcclusionBundle;
 use bevy::core_pipeline::experimental::taa::TemporalAntiAliasBundle;

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -13,7 +13,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugins(Sprite3dPlugin)
-        .add_state::<GameState>()
+        .init_state::<GameState>()
 
         // initially load assets
         .add_systems( Startup, |asset_server: Res<AssetServer>, mut assets: ResMut<Assets>| {

--- a/examples/sprite_sheet.rs
+++ b/examples/sprite_sheet.rs
@@ -8,7 +8,7 @@ enum GameState { #[default] Loading, Ready }
 #[derive(Resource, Default)]
 struct ImageAssets {
     image: Handle<Image>,        // the `image` field here is only used to query the load state, lots of the
-    atlas: Handle<TextureAtlas>, // code in this file disappears if something like bevy_asset_loader is used.
+    layout: Handle<TextureAtlasLayout>, // code in this file disappears if something like bevy_asset_loader is used.
 }
 
 #[derive(Component, Deref, DerefMut)]
@@ -19,17 +19,16 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_plugins(Sprite3dPlugin)
-        .add_state::<GameState>()
+        .init_state::<GameState>()
 
         // initially load assets
         .add_systems(Startup, |asset_server:         Res<AssetServer>,
                                mut assets:           ResMut<ImageAssets>,
-                               mut texture_atlases:  ResMut<Assets<TextureAtlas>>| {
+                               mut texture_atlases:  ResMut<Assets<TextureAtlasLayout>>| {
 
             assets.image = asset_server.load("gabe-idle-run.png");
-
-            assets.atlas = texture_atlases.add(
-                TextureAtlas::from_grid(assets.image.clone(), Vec2::new(24.0, 24.0), 7, 1, None, None)
+            assets.layout = texture_atlases.add(
+                TextureAtlasLayout::from_grid(Vec2::new(24.0, 24.0), 7, 1, None, None)
             );
         })
 
@@ -65,20 +64,21 @@ fn setup(
 
     // -------------------- Spawn a 3D atlas sprite --------------------------
 
-    commands.spawn(AtlasSprite3d {
-            atlas: assets.atlas.clone(),
+    let texture_atlas = TextureAtlas {
+        layout: assets.layout.clone(),
+        index: 3,
+    };
 
+    commands.spawn(Sprite3d {
+            image: assets.image.clone(),
             pixels_per_metre: 32.,
             alpha_mode: AlphaMode::Blend,
             unlit: true,
-
-            index: 3,
-
             // transform: Transform::from_xyz(0., 0., 0.),
             // pivot: Some(Vec2::new(0.5, 0.5)),
 
             ..default()
-    }.bundle(&mut sprite_params))
+    }.bundle_with_atlas(&mut sprite_params, texture_atlas))
     .insert(AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)));
 
     // -----------------------------------------------------------------------
@@ -87,12 +87,12 @@ fn setup(
 
 fn animate_sprite(
     time: Res<Time>,
-    mut query: Query<(&mut AnimationTimer, &mut AtlasSprite3dComponent)>,
+    mut query: Query<(&mut AnimationTimer, &mut TextureAtlas, &AtlasSprite3dKeys)>,
 ) {
-    for (mut timer, mut sprite) in query.iter_mut() {
+    for (mut timer, mut atlas, keys) in query.iter_mut() {
         timer.tick(time.delta());
         if timer.just_finished() {
-            sprite.index = (sprite.index + 1) % sprite.atlas.len();
+            atlas.index = (atlas.index + 1) % keys.len();
         }
     }
 }

--- a/examples/sprite_sheet.rs
+++ b/examples/sprite_sheet.rs
@@ -87,12 +87,12 @@ fn setup(
 
 fn animate_sprite(
     time: Res<Time>,
-    mut query: Query<(&mut AnimationTimer, &mut TextureAtlas, &AtlasSprite3dKeys)>,
+    mut query: Query<(&mut AnimationTimer, &mut TextureAtlas, &TextureAtlas3dData)>,
 ) {
-    for (mut timer, mut atlas, keys) in query.iter_mut() {
+    for (mut timer, mut atlas, data) in query.iter_mut() {
         timer.tick(time.delta());
         if timer.just_finished() {
-            atlas.index = (atlas.index + 1) % keys.len();
+            atlas.index = (atlas.index + 1) % data.keys.len();
         }
     }
 }

--- a/examples/sprite_sheet.rs
+++ b/examples/sprite_sheet.rs
@@ -7,7 +7,7 @@ enum GameState { #[default] Loading, Ready }
 
 #[derive(Resource, Default)]
 struct ImageAssets {
-    image: Handle<Image>,        // the `image` field here is only used to query the load state, lots of the
+    image: Handle<Image>,               // the `image` field here is only used to query the load state, lots of the
     layout: Handle<TextureAtlasLayout>, // code in this file disappears if something like bevy_asset_loader is used.
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy::render::{ mesh::*, render_resource::*, render_asset::RenderAssetPersistencePolicy };
+use bevy::render::{ mesh::*, render_resource::*, render_asset::RenderAssetUsages};
 use std::hash::Hash;
 use std::collections::HashMap;
 
@@ -114,9 +114,13 @@ fn quad(w: f32, h: f32, pivot: Option<Vec2>, double_sided: bool) -> Mesh {
     let w2 = w / 2.0;
     let h2 = h / 2.0;
 
-    // Set the PersistencePolicy to the default value. Maybe allow customization or
+    // Set RenderAssetUsages to the default value. Maybe allow customization or
     // choose a better default?
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList, RenderAssetPersistencePolicy::default());
+    let mut mesh = Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::default(),
+    );
+
     let vertices = match pivot {
         None => { vec![[-w2, -h2, 0.0], [w2, -h2, 0.0], [-w2, h2, 0.0], [w2, h2, 0.0],
                        [-w2, -h2, 0.0], [w2, -h2, 0.0], [-w2, h2, 0.0], [w2, h2, 0.0]] },
@@ -136,10 +140,10 @@ fn quad(w: f32, h: f32, pivot: Option<Vec2>, double_sided: bool) -> Mesh {
     mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vec![[0.0, 1.0], [1.0, 1.0], [0.0, 0.0], [1.0, 0.0],
                                                      [0.0, 1.0], [1.0, 1.0], [0.0, 0.0], [1.0, 0.0]]);
 
-    mesh.set_indices(Some(Indices::U32(
+    mesh.insert_indices(Indices::U32(
         if double_sided { vec![0, 1, 2, 1, 3, 2, 5, 4, 6, 7, 5, 6] }
         else {            vec![0, 1, 2, 1, 3, 2] }
-    )));
+    ));
 
     mesh
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy::render::{ mesh::*, render_resource::* };
+use bevy::render::{ mesh::*, render_resource::*, render_asset::RenderAssetPersistencePolicy };
 use std::hash::Hash;
 use std::collections::HashMap;
 
@@ -21,11 +21,11 @@ use bevy::ecs::system::SystemParam;
 // everything needed to register a sprite, passed in one go.
 #[derive(SystemParam)]
 pub struct Sprite3dParams<'w, 's> {
-    pub meshes    : ResMut<'w, Assets<Mesh>>,
-    pub materials : ResMut<'w, Assets<StandardMaterial>>,
-    pub images    : ResMut<'w, Assets<Image>>,
-    pub atlases   : ResMut<'w, Assets<TextureAtlas>>,
-    pub sr        : ResMut<'w, Sprite3dRes>,
+    pub meshes        : ResMut<'w, Assets<Mesh>>,
+    pub materials     : ResMut<'w, Assets<StandardMaterial>>,
+    pub images        : ResMut<'w, Assets<Image>>,
+    pub atlas_layouts : ResMut<'w, Assets<TextureAtlasLayout>>,
+    pub sr            : ResMut<'w, Sprite3dRes>,
     #[system_param(ignore)]
     marker: PhantomData<&'s usize>,
 }
@@ -89,14 +89,17 @@ impl Default for Sprite3dRes {
 
 
 
-// Update the mesh of any AtlasSprite3d when its index changes.
+// Update the mesh of a Sprite3d + AtlasSprite when its index changes.
 fn sprite3d_system(
     sprite_params: Sprite3dParams,
-    mut query: Query<(&mut Handle<Mesh>, &AtlasSprite3dComponent), Changed<AtlasSprite3dComponent>>,
+    mut query: Query<
+        (&mut Handle<Mesh>, &TextureAtlas, &TextureAtlas3dData),
+        (With<Sprite3dComponent>, Changed<TextureAtlas>),
+    >,
 ) {
-    for (mut mesh, params) in query.iter_mut() {
+    for (mut mesh, atlas, data) in query.iter_mut() {
         // this unwrap will always succeed, unless mesh_cache is corrupted.
-        *mesh = sprite_params.sr.mesh_cache.get(&params.atlas[params.index]).unwrap().clone();
+        *mesh = sprite_params.sr.mesh_cache.get(&data.keys[atlas.index]).unwrap().clone();
     }
 }
 
@@ -110,7 +113,10 @@ fn sprite3d_system(
 fn quad(w: f32, h: f32, pivot: Option<Vec2>, double_sided: bool) -> Mesh {
     let w2 = w / 2.0;
     let h2 = h / 2.0;
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+
+    // Set the PersistencePolicy to the default value. Maybe allow customization or
+    // choose a better default?
+    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList, RenderAssetPersistencePolicy::default());
     let vertices = match pivot {
         None => { vec![[-w2, -h2, 0.0], [w2, -h2, 0.0], [-w2, h2, 0.0], [w2, h2, 0.0],
                        [-w2, -h2, 0.0], [w2, -h2, 0.0], [-w2, h2, 0.0], [w2, h2, 0.0]] },
@@ -222,7 +228,13 @@ impl Default for Sprite3d {
 
 // just a marker for queries at the moment, could be expanded later if needed.
 #[derive(Component)]
-pub struct Sprite3dComponent { }
+pub struct Sprite3dComponent {}
+
+// Stores mesh keys since the previous AtlasSprite3dComponent was removed.
+#[derive(Component)]
+pub struct TextureAtlas3dData {
+    keys: Vec<[u32; 9]>,
+}
 
 #[derive(Bundle)]
 pub struct Sprite3dBundle {
@@ -230,8 +242,15 @@ pub struct Sprite3dBundle {
     pub pbr: PbrBundle,
 }
 
-impl Sprite3d {
+#[derive(Bundle)]
+pub struct AtlasSprite3dBundle {
+    pub params: Sprite3dComponent,
+    pub data: TextureAtlas3dData,
+    pub pbr: PbrBundle,
+    pub atlas: TextureAtlas,
+}
 
+impl Sprite3d {
     /// creates a bundle of components from the Sprite3d struct.
     pub fn bundle(self, params: &mut Sprite3dParams ) -> Sprite3dBundle {
         // get image dimensions
@@ -240,9 +259,8 @@ impl Sprite3d {
         let w = (image_size.width  as f32) / self.pixels_per_metre;
         let h = (image_size.height as f32) / self.pixels_per_metre;
 
-
         return Sprite3dBundle {
-            params: Sprite3dComponent { },
+            params: Sprite3dComponent {},
             pbr: PbrBundle {
                 mesh: {
                     let pivot = self.pivot.unwrap_or(Vec2::new(0.5, 0.5));
@@ -290,100 +308,15 @@ impl Sprite3d {
             }
         }
     }
-}
 
-
-
-
-
-
-
-
-
-/// Same as Sprite3d, but for sprites in a texture atlas.
-///
-/// A precursor struct for a sprite. Set necessary parameters manually, use
-/// `..default()` for others, then call `bundle()` to to get a `PBRBundle`
-/// that can be spawned into the world.
-pub struct AtlasSprite3d {
-    /// the sprite's transform
-    pub transform: Transform,
-    /// the sprite texture atlas. See `readme.md` for examples.
-    pub atlas: Handle<TextureAtlas>,
-    /// the sprite's index in the atlas.
-    pub index: usize,
-
-    /// the number of pixels per metre of the sprite, assuming a `Transform::scale` of 1.0.
-    pub pixels_per_metre: f32,
-
-    /// The sprite's pivot. eg. the point specified by the sprite's
-    /// transform, around which a rotation will be performed.
-    ///
-    /// - pivot = None will have a center pivot
-    /// - pivot = Some(p) will have an expected range of p \in `(0,0)` to `(1,1)`
-    ///   (though you can go out of bounds without issue)
-    pub pivot: Option<Vec2>,
-
-    /// The sprite's alpha mode.
-    ///
-    /// - `Mask(0.5)` (default) only allows fully opaque or fully transparent pixels
-    ///   (cutoff at `0.5`).
-    /// - `Blend` allows partially transparent pixels (slightly more expensive).
-    /// - Use any other value to achieve desired blending effect.
-    pub alpha_mode: AlphaMode,
-
-    /// Whether the sprite should be rendered as unlit.
-    /// `false` (default) allows for lighting.
-    pub unlit: bool,
-
-    /// Whether the sprite should be rendered as double-sided.
-    /// `true` (default) adds a second set of indices, describing the same tris
-    /// in reverse order.
-    pub double_sided: bool,
-
-    /// An emissive colour, if the sprite should emit light.
-    /// `Color::Black` (default) does nothing.
-    pub emissive: Color,
-}
-
-impl Default for AtlasSprite3d {
-    fn default() -> AtlasSprite3d {
-        AtlasSprite3d {
-            transform: Transform::default(),
-            atlas: Handle::<TextureAtlas>::default(),
-            index: 0,
-            pixels_per_metre: 100.,
-            pivot: None,
-            alpha_mode: DEFAULT_ALPHA_MODE,
-            unlit: false,
-            double_sided: true,
-            emissive: Color::BLACK,
-        }
-    }
-}
-
-
-
-#[derive(Component)]
-pub struct AtlasSprite3dComponent {
-    pub index: usize,
-    pub atlas: Vec<[u32; 9]>,
-}
-
-#[derive(Bundle)]
-pub struct AtlasSprite3dBundle {
-    pub params: AtlasSprite3dComponent,
-    pub pbr: PbrBundle,
-}
-
-
-
-
-impl AtlasSprite3d {
     /// creates a bundle of components from the AtlasSprite3d struct.
-    pub fn bundle(self, params: &mut Sprite3dParams ) -> AtlasSprite3dBundle {
-        let atlas = params.atlases.get(&self.atlas).unwrap();
-        let image = params.images.get(&atlas.texture).unwrap();
+    pub fn bundle_with_atlas(
+        self,
+        params: &mut Sprite3dParams,
+        atlas: TextureAtlas,
+    ) -> AtlasSprite3dBundle {
+        let atlas_layout = params.atlas_layouts.get(&atlas.layout).unwrap();
+        let image = params.images.get(&self.image).unwrap();
         let image_size = image.texture_descriptor.size;
 
         let pivot = self.pivot.unwrap_or(Vec2::new(0.5, 0.5));
@@ -394,9 +327,9 @@ impl AtlasSprite3d {
         let mut mesh_keys = Vec::new();
 
 
-        for i in 0..atlas.textures.len() {
+        for i in 0..atlas_layout.textures.len() {
 
-            let rect = atlas.textures[i];
+            let rect = atlas_layout.textures[i];
 
             let w = rect.width() / self.pixels_per_metre;
             let h = rect.height() / self.pixels_per_metre;
@@ -450,17 +383,17 @@ impl AtlasSprite3d {
 
         return AtlasSprite3dBundle {
             pbr: PbrBundle {
-                mesh: params.sr.mesh_cache.get(&mesh_keys[self.index]).unwrap().clone(),
+                mesh: params.sr.mesh_cache.get(&mesh_keys[atlas.index]).unwrap().clone(),
                 material: {
                     let mat_key = MatKey {
-                        image: atlas.texture.clone(),
+                        image: self.image.clone(),
                         alpha_mode: HashableAlphaMode(self.alpha_mode),
                         unlit: self.unlit,
                         emissive: reduce_colour(self.emissive),
                     };
                     if let Some(material) = params.sr.material_cache.get(&mat_key) { material.clone() }
                     else {
-                        let material = params.materials.add(material(atlas.texture.clone(), self.alpha_mode, self.unlit, self.emissive));
+                        let material = params.materials.add(material(self.image.clone(), self.alpha_mode, self.unlit, self.emissive));
                         params.sr.material_cache.insert(mat_key, material.clone());
                         material
                     }
@@ -469,10 +402,11 @@ impl AtlasSprite3d {
                 transform: self.transform,
                 ..default()
             },
-            params: AtlasSprite3dComponent {
-                index: self.index,
-                atlas: mesh_keys,
+            params: Sprite3dComponent {},
+            data: TextureAtlas3dData {
+                keys: mesh_keys,
             },
+            atlas,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ pub struct Sprite3dComponent {}
 // Stores mesh keys since the previous AtlasSprite3dComponent was removed.
 #[derive(Component)]
 pub struct TextureAtlas3dData {
-    keys: Vec<[u32; 9]>,
+    pub keys: Vec<[u32; 9]>,
 }
 
 #[derive(Bundle)]


### PR DESCRIPTION
`AtlasSprite` got reworked in the upcoming Bevy 0.13, so here's my attempt to incorporate those changes into bevy_sprite3d. (Hopefully I'm not rushing by submitting a PR before the release is even out.) In summary: 

* `AtlasSprite3d` is gone and replaced by a method on `Sprite3d`, `bundle_with_atlas` that takes a `Sprite3dParams` and an `AtlasSprite` and returns a reworked `AtlasSprite3dBundle`.
* A new component `TextureAtlas3dData` replaces `AtlasSprite3dComponent` -- the only thing it does is hold the mesh keys associated with the atlas.
* The only distinction between an atlas and non-atlas `Sprite3d` is the presence of the `TextureAtlas` and `TextureAtlas3dData` components.
* All `Assets<AtlasSprite>` have been replaced with `Assets<Image>` and `Assets<AtlasSpriteLayout>`, including in `Sprite3dParams`, with variables and properties appropriately renamed.

Not directly related to the PR, but the signature of `Mesh::new` got changed to require a `RenderAssetPersistencePolicy` argument — I put in a safe default for now, but you might want to change that.

The examples have been updated *except* for the ones using bevy_asset_loader — I don't know how bevy_asset_loader plans to handle the new texture atlases, so I've left them alone for now. The `dungeon` example also looks different because of lighting system changes in 0.13, but I'll leave that for another PR to fix.