### PR TITLE
Upgrade to Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/FraserLee/bevy_sprite3d"
 keywords = ["gamedev", "bevy", "sprite", "3d"]
 
 [dependencies.bevy]
-version = "0.14"
+version = "0.15"
 default-features = false
-features = ["bevy_asset", "bevy_pbr", "bevy_sprite"]
+features = ["bevy_asset", "bevy_pbr", "bevy_sprite", "png"]
 
 [dev-dependencies]
-bevy.version = "0.14" # (include default features when running examples)
+bevy.version = "0.15" # (include default features when running examples)
 rand = "0.8"

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use bevy::asset::LoadState;
 use bevy_sprite3d::prelude::*;
 
 #[derive(States, Hash, Clone, PartialEq, Eq, Debug, Default)]
@@ -38,18 +37,17 @@ fn setup(
 ) {
 
     // poll every frame to check if assets are loaded. Once they are, we can proceed with setup.
-    if asset_server.get_load_state(assets.0.id()) != Some(LoadState::Loaded) { return; }
+    if !asset_server.get_load_state(assets.0.id()).is_some_and(|s| s.is_loaded()) { return; }
 
     next_state.set(GameState::Ready);
 
     // -----------------------------------------------------------------------
 
-    commands.spawn(Camera3dBundle::default())
-            .insert(Transform::from_xyz(0., 0., 5.));
+    commands.spawn(Camera3d::default()).insert(Transform::from_xyz(0., 0., 5.));
 
     // ----------------------- Spawn a 3D sprite -----------------------------
 
-    commands.spawn(Sprite3d {
+    commands.spawn(Sprite3dBuilder {
             image: assets.0.clone(),
 
             pixels_per_metre: 400.,
@@ -58,7 +56,6 @@ fn setup(
 
             unlit: true,
 
-            // transform: Transform::from_xyz(0., 0., 0.),
             // pivot: Some(Vec2::new(0.5, 0.5)),
 
             ..default()

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,9 +1,7 @@
 pub use crate::{
-    AtlasSprite3dBundle,
     Sprite3d,
+    Sprite3dBuilder,
     Sprite3dBundle,
-    Sprite3dComponent,
     Sprite3dParams,
     Sprite3dPlugin,
-    TextureAtlas3dData,
 };


### PR DESCRIPTION
Update to make the crate compatible with 0.15. This is relatively minimal, taking full advantage of all the new features would probably require a major rework.

* `Sprite3d` was renamed to `Sprite3dBuilder` and no longer has a `transform` field.
* `Sprite3dComponent` was renamed to `Sprite3d`. It requires `Transform` and `Mesh3d`
   and contains the fields `texture_atlas` and `texture_atlas_keys`, both optional.
* `Sprite3dBundle` now contains `Mesh3d` and `MaterialMesh3d` instead of `PbrBundle`.
* `AtlasSprite3dBundle` and `AtlasSprite3dData` were removed.
* `Sprite3dRes` was renamed to `Sprite3dCaches`, with its corresponding field in `Sprite3dParams` renamed to `caches`. This isn't directly related to 0.15 but might as well be more specific while changing things up in general. For similar reasons, the internal `sprite3d_system` was renamed to `handle_texture_atlases`.
* Switched internally from `std::collections::HashMap` to `bevy::utils::HashMap`.
* Temporarily enabled the feature `bevy/png` to deal with bevyengine/bevy#16563.
* Updated all the examples.
