### PR TITLE
Support update image and atlas through `Sprite`

### DIFF
--- a/examples/dungeon.rs
+++ b/examples/dungeon.rs
@@ -211,11 +211,10 @@ fn spawn_sprites(
 
             commands.spawn((
                 Sprite3dBuilder {
-                    image: images.image.clone(),
                     pixels_per_metre: 16.,
                     double_sided: false,
                     ..default()
-                }.bundle_with_atlas(&mut sprite_params, atlas),
+                }.bundle_with_atlas(&mut sprite_params, images.image.clone(), atlas),
                 Transform::from_xyz(x, 0.0, y)
                     .with_rotation(Quat::from_rotation_x(-std::f32::consts::PI / 2.0))
             ));
@@ -267,11 +266,10 @@ fn spawn_sprites(
                 
                 commands.spawn((
                     Sprite3dBuilder {
-                        image: images.image.clone(),
                         pixels_per_metre: 16.,
                         double_sided: false,
                         ..default()
-                    }.bundle_with_atlas(&mut sprite_params, atlas),
+                    }.bundle_with_atlas(&mut sprite_params, images.image.clone(), atlas),
                     Transform::from_xyz(x+0.5, i as f32 + 0.499, y)
                         .with_rotation(Quat::from_rotation_y(dir * std::f32::consts::PI / 2.0))
                 ));
@@ -305,11 +303,10 @@ fn spawn_sprites(
 
                 commands.spawn((
                     Sprite3dBuilder {
-                        image: images.image.clone(),
                         pixels_per_metre: 16.,
                         double_sided: false,
                         ..default()
-                    }.bundle_with_atlas(&mut sprite_params, atlas),
+                    }.bundle_with_atlas(&mut sprite_params, images.image.clone(), atlas),
                     Transform::from_xyz(x, i as f32 + 0.499, y + 0.5)
                         .with_rotation(Quat::from_rotation_y((dir - 1.0) * std::f32::consts::PI / 2.0)),
                 ));
@@ -331,10 +328,9 @@ fn spawn_sprites(
 
             let mut c = commands.spawn((
                 Sprite3dBuilder {
-                    image: images.image.clone(),
                     pixels_per_metre: 16.,
                     ..default()
-                }.bundle_with_atlas(&mut sprite_params, atlas),
+                }.bundle_with_atlas(&mut sprite_params, images.image.clone(), atlas),
                 FaceCamera {},
                 Transform::from_xyz(x as f32, i as f32 + 0.498, y),
             ));
@@ -371,12 +367,11 @@ fn spawn_sprites(
     };
 
     commands.spawn((Sprite3dBuilder {
-            image: images.image.clone(),
             pixels_per_metre: 16.,
             emissive: LinearRgba::rgb(1.0, 0.5, 0.0) * 10.0,
             unlit: true,
             ..default()
-        }.bundle_with_atlas(&mut sprite_params, atlas),
+        }.bundle_with_atlas(&mut sprite_params, images.image.clone(), atlas),
         Transform::from_xyz(2.0, 0.5, -5.5),
         Animation {
             frames: vec![30*32 + 14, 30*32 + 15, 30*32 + 16],
@@ -403,12 +398,11 @@ fn spawn_sprites(
 
     commands.spawn((
         Sprite3dBuilder {
-            image: images.image.clone(),
             pixels_per_metre: 16.,
             emissive: LinearRgba::rgb(165./255., 1.0, 160./255.),
             unlit: true,
             ..default()
-        }.bundle_with_atlas(&mut sprite_params, atlas),
+        }.bundle_with_atlas(&mut sprite_params, images.image.clone(), atlas),
         Transform::from_xyz(-5., 0.7, 6.5),
         FaceCamera {}
     ));
@@ -451,12 +445,12 @@ fn animate_camera(
 
 fn animate_sprites(
     time: Res<Time>,
-    mut query: Query<(&mut Animation, &mut Sprite3d)>,
+    mut query: Query<(&mut Animation, &mut Sprite)>,
 ) {
-    for (mut animation, mut sprite_3d) in query.iter_mut() {
+    for (mut animation, mut sprite) in query.iter_mut() {
         animation.timer.tick(time.delta());
         if animation.timer.just_finished() {
-            let atlas = sprite_3d.texture_atlas.as_mut().unwrap();
+            let atlas = sprite.texture_atlas.as_mut().unwrap();
             atlas.index = animation.frames[animation.current];
             animation.current += 1;
             animation.current %= animation.frames.len();

--- a/examples/dungeon.rs
+++ b/examples/dungeon.rs
@@ -132,7 +132,6 @@ fn setup(
 fn spawn_sprites(
     mut commands: Commands,
     images: Res<ImageAssets>,
-    mut sprite_params: Sprite3dParams,
 ) {
     // ------------------ Tilemap for the floor ------------------
 
@@ -210,11 +209,16 @@ fn spawn_sprites(
             };
 
             commands.spawn((
-                Sprite3dBuilder {
+                Sprite3d {
                     pixels_per_metre: 16.,
                     double_sided: false,
                     ..default()
-                }.bundle_with_atlas(&mut sprite_params, images.image.clone(), atlas),
+                },
+                Sprite {
+                    image: images.image.clone(),
+                    texture_atlas: Some(atlas),
+                    ..default()
+                },
                 Transform::from_xyz(x, 0.0, y)
                     .with_rotation(Quat::from_rotation_x(-std::f32::consts::PI / 2.0))
             ));
@@ -265,11 +269,16 @@ fn spawn_sprites(
                 };
                 
                 commands.spawn((
-                    Sprite3dBuilder {
+                    Sprite3d {
                         pixels_per_metre: 16.,
                         double_sided: false,
                         ..default()
-                    }.bundle_with_atlas(&mut sprite_params, images.image.clone(), atlas),
+                    },
+                    Sprite {
+                        image: images.image.clone(),
+                        texture_atlas: Some(atlas),
+                        ..default()
+                    },
                     Transform::from_xyz(x+0.5, i as f32 + 0.499, y)
                         .with_rotation(Quat::from_rotation_y(dir * std::f32::consts::PI / 2.0))
                 ));
@@ -302,11 +311,16 @@ fn spawn_sprites(
                 };
 
                 commands.spawn((
-                    Sprite3dBuilder {
+                    Sprite3d {
                         pixels_per_metre: 16.,
                         double_sided: false,
                         ..default()
-                    }.bundle_with_atlas(&mut sprite_params, images.image.clone(), atlas),
+                    },
+                    Sprite {
+                        image: images.image.clone(),
+                        texture_atlas: Some(atlas),
+                        ..default()
+                    },
                     Transform::from_xyz(x, i as f32 + 0.499, y + 0.5)
                         .with_rotation(Quat::from_rotation_y((dir - 1.0) * std::f32::consts::PI / 2.0)),
                 ));
@@ -327,10 +341,15 @@ fn spawn_sprites(
             };
 
             let mut c = commands.spawn((
-                Sprite3dBuilder {
+                Sprite3d {
                     pixels_per_metre: 16.,
                     ..default()
-                }.bundle_with_atlas(&mut sprite_params, images.image.clone(), atlas),
+                },
+                Sprite {
+                    image: images.image.clone(),
+                    texture_atlas: Some(atlas),
+                    ..default()
+                },
                 FaceCamera {},
                 Transform::from_xyz(x as f32, i as f32 + 0.498, y),
             ));
@@ -366,12 +385,17 @@ fn spawn_sprites(
         index: 30*32 + 14,
     };
 
-    commands.spawn((Sprite3dBuilder {
+    commands.spawn((Sprite3d {
             pixels_per_metre: 16.,
             emissive: LinearRgba::rgb(1.0, 0.5, 0.0) * 10.0,
             unlit: true,
             ..default()
-        }.bundle_with_atlas(&mut sprite_params, images.image.clone(), atlas),
+        },
+        Sprite {
+            image: images.image.clone(),
+            texture_atlas: Some(atlas),
+            ..default()
+        },
         Transform::from_xyz(2.0, 0.5, -5.5),
         Animation {
             frames: vec![30*32 + 14, 30*32 + 15, 30*32 + 16],
@@ -397,12 +421,17 @@ fn spawn_sprites(
     };
 
     commands.spawn((
-        Sprite3dBuilder {
+        Sprite3d {
             pixels_per_metre: 16.,
             emissive: LinearRgba::rgb(165./255., 1.0, 160./255.),
             unlit: true,
             ..default()
-        }.bundle_with_atlas(&mut sprite_params, images.image.clone(), atlas),
+        },
+        Sprite {
+            image: images.image.clone(),
+            texture_atlas: Some(atlas),
+            ..default()
+        },
         Transform::from_xyz(-5., 0.7, 6.5),
         FaceCamera {}
     ));

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -48,8 +48,6 @@ fn setup(
     // ----------------------- Spawn a 3D sprite -----------------------------
 
     commands.spawn(Sprite3dBuilder {
-            image: assets.0.clone(),
-
             pixels_per_metre: 400.,
 
             alpha_mode: AlphaMode::Blend,
@@ -59,7 +57,7 @@ fn setup(
             // pivot: Some(Vec2::new(0.5, 0.5)),
 
             ..default()
-    }.bundle(&mut sprite_params));
+    }.bundle(&mut sprite_params, assets.0.clone()));
 
     // -----------------------------------------------------------------------
 }

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -33,7 +33,6 @@ fn setup(
     assets            : Res<Assets>,
     mut commands      : Commands,
     mut next_state    : ResMut<NextState<GameState>>,
-    mut sprite_params : Sprite3dParams
 ) {
 
     // poll every frame to check if assets are loaded. Once they are, we can proceed with setup.
@@ -47,7 +46,8 @@ fn setup(
 
     // ----------------------- Spawn a 3D sprite -----------------------------
 
-    commands.spawn(Sprite3dBuilder {
+    commands.spawn((
+        Sprite3d {
             pixels_per_metre: 400.,
 
             alpha_mode: AlphaMode::Blend,
@@ -57,7 +57,12 @@ fn setup(
             // pivot: Some(Vec2::new(0.5, 0.5)),
 
             ..default()
-    }.bundle(&mut sprite_params, assets.0.clone()));
+        },
+        Sprite {
+            image: assets.0.clone(),
+            ..default()
+        }
+    ));
 
     // -----------------------------------------------------------------------
 }

--- a/examples/sprite_sheet.rs
+++ b/examples/sprite_sheet.rs
@@ -48,7 +48,6 @@ fn setup(
     assets            : Res<ImageAssets>,
     mut commands      : Commands,
     mut next_state    : ResMut<NextState<GameState>>,
-    mut sprite_params : Sprite3dParams
 ) {
 
     // poll every frame to check if assets are loaded. Once they are, we can proceed with setup.
@@ -66,14 +65,17 @@ fn setup(
         index: 3,
     };
 
-    commands.spawn(Sprite3dBuilder {
+    commands.spawn((
+        Sprite { image: assets.image.clone(), texture_atlas: Some(texture_atlas), ..default() },
+        Sprite3d {
             pixels_per_metre: 32.,
             alpha_mode: AlphaMode::Blend,
             unlit: true,
             // pivot: Some(Vec2::new(0.5, 0.5)),
             ..default()
-    }.bundle_with_atlas(&mut sprite_params, assets.image.clone(), texture_atlas))
-    .insert(AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)));
+        },
+        AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)),
+    ));
 
     // -----------------------------------------------------------------------
 }

--- a/examples/sprite_sheet.rs
+++ b/examples/sprite_sheet.rs
@@ -67,13 +67,12 @@ fn setup(
     };
 
     commands.spawn(Sprite3dBuilder {
-            image: assets.image.clone(),
             pixels_per_metre: 32.,
             alpha_mode: AlphaMode::Blend,
             unlit: true,
             // pivot: Some(Vec2::new(0.5, 0.5)),
             ..default()
-    }.bundle_with_atlas(&mut sprite_params, texture_atlas))
+    }.bundle_with_atlas(&mut sprite_params, assets.image.clone(), texture_atlas))
     .insert(AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)));
 
     // -----------------------------------------------------------------------
@@ -82,14 +81,16 @@ fn setup(
 
 fn animate_sprite(
     time: Res<Time>,
-    mut query: Query<(&mut AnimationTimer, &mut Sprite3d)>,
+    atlases: Res<Assets<TextureAtlasLayout>>,
+    mut query: Query<(&mut AnimationTimer, &mut Sprite)>,
 ) {
-    for (mut timer, mut sprite_3d) in query.iter_mut() {
+    for (mut timer, mut sprite) in query.iter_mut() {
         timer.tick(time.delta());
         if timer.just_finished() {
-            let length = sprite_3d.texture_atlas_keys.as_ref().unwrap().len();
-            let atlas = sprite_3d.texture_atlas.as_mut().unwrap();
-            atlas.index = (atlas.index + 1) % length;
+            let atlas = sprite.texture_atlas.as_mut().unwrap();
+            if let Some(layouts) = atlases.get(&atlas.layout) {
+                atlas.index = (atlas.index + 1) % layouts.textures.len();
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub struct Sprite3dPlugin;
 impl Plugin for Sprite3dPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<Sprite3dCaches>();
-        app.add_systems(PostUpdate, handle_texture_atlases);
+        app.add_systems(PostUpdate, (handle_texture_atlases, handle_images));
     }
 }
 
@@ -38,6 +38,8 @@ pub struct MatKey {
     alpha_mode: HashableAlphaMode,
     unlit: bool,
     emissive: [u8; 4],
+    flip_x: bool,
+    flip_y: bool,
 }
 
 const DEFAULT_ALPHA_MODE: AlphaMode = AlphaMode::Mask(0.5);
@@ -87,18 +89,41 @@ impl Default for Sprite3dCaches {
 }
 
 
+fn handle_images(
+    mut caches: ResMut<Sprite3dCaches>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut query: Query<(&mut MeshMaterial3d<StandardMaterial>, &Sprite, &Sprite3d), Changed<Sprite>>) {
+    for (mut mesh, sprite, sprite_3d) in query.iter_mut() {
+        let current_mat = &mesh.0;
+        let mat_key = MatKey {
+            image: sprite.image.clone(),
+            alpha_mode: HashableAlphaMode(sprite_3d.alpha_mode),
+            unlit: sprite_3d.unlit,
+            emissive: reduce_colour(sprite_3d.emissive),
+            flip_x: sprite.flip_x,
+            flip_y: sprite.flip_y,
+        };
+        let mat = if let Some(material) = caches.material_cache.get(&mat_key) { material.clone() } else {
+            let mut material = material(sprite.image.clone(), sprite_3d.alpha_mode, sprite_3d.unlit, sprite_3d.emissive);
+            material.flip(mat_key.flip_x, mat_key.flip_y);
+            let material = materials.add(material);
+            caches.material_cache.insert(mat_key, material.clone());
+            material
+        };
 
-
-
-
+        if *current_mat != mat {
+            *mesh = MeshMaterial3d(mat);
+        }
+    }
+}
 
 // Update the mesh of a Sprite3d with an atlas sprite when its index changes.
 fn handle_texture_atlases(
     caches: Res<Sprite3dCaches>,
-    mut query: Query<(&mut Mesh3d, &Sprite3d), Changed<Sprite3d>>,
+    mut query: Query<(&mut Mesh3d, &Sprite3d, &Sprite), Changed<Sprite>>,
 ) {
-    for (mut mesh, sprite_3d) in query.iter_mut() {
-        let Some(texture_atlas) = &sprite_3d.texture_atlas else {
+    for (mut mesh, sprite_3d, sprite) in query.iter_mut() {
+        let Some(texture_atlas) = &sprite.texture_atlas else {
             continue;
         };
         let Some(mesh_keys) = &sprite_3d.texture_atlas_keys else {
@@ -179,9 +204,6 @@ fn material(image: Handle<Image>, alpha_mode: AlphaMode, unlit: bool, emissive: 
 /// `..default()` for others, then call `bundle()` to to get a bundle
 /// that can be spawned into the world.
 pub struct Sprite3dBuilder {
-    /// the sprite image. See `readme.md` for examples.
-    pub image: Handle<Image>,
-
     // TODO: ability to specify exact size, with None scaled by image's ratio and other.
 
     /// the number of pixels per metre of the sprite, assuming a `Transform::scale` of 1.0.
@@ -220,7 +242,6 @@ pub struct Sprite3dBuilder {
 impl Default for Sprite3dBuilder {
     fn default() -> Self {
         Self {
-            image: Default::default(),
             pixels_per_metre: 100.,
             pivot: None,
             alpha_mode: DEFAULT_ALPHA_MODE,
@@ -235,15 +256,31 @@ impl Default for Sprite3dBuilder {
 /// Represents a 3D sprite. May store texture atlas data -- note that modifying
 /// `texture_atlas` and `texture_atlas_keys` on an already spawned sprite may
 /// cause buggy behavior.
-#[derive(Component)]
-#[require(Transform, Mesh3d)]
+#[derive(Component, Default)]
+#[require(Transform, Mesh3d, Sprite)]
 pub struct Sprite3d {
-    pub texture_atlas: Option<TextureAtlas>,
     pub texture_atlas_keys: Option<Vec<[u32; 9]>>,
+
+    /// The sprite's alpha mode.
+    ///
+    /// - `Mask(0.5)` (default) only allows fully opaque or fully transparent pixels
+    ///   (cutoff at `0.5`).
+    /// - `Blend` allows partially transparent pixels (slightly more expensive).
+    /// - Use any other value to achieve desired blending effect.
+    pub alpha_mode: AlphaMode,
+
+    /// Whether the sprite should be rendered as unlit.
+    /// `false` (default) allows for lighting.
+    pub unlit: bool,
+
+    /// An emissive colour, if the sprite should emit light.
+    /// `LinearRgba::Black` (default) does nothing.
+    pub emissive: LinearRgba,
 }
 
 #[derive(Bundle)]
 pub struct Sprite3dBundle {
+    pub sprite: Sprite,
     pub sprite_3d: Sprite3d,
     pub mesh: Mesh3d,
     pub material: MeshMaterial3d<StandardMaterial>,
@@ -251,18 +288,15 @@ pub struct Sprite3dBundle {
 
 impl Sprite3dBuilder {
     /// creates a bundle of components
-    pub fn bundle(self, params: &mut Sprite3dParams) -> Sprite3dBundle {
+    pub fn bundle(self, params: &mut Sprite3dParams, handle_image: Handle<Image>) -> Sprite3dBundle {
         // get image dimensions
-        let image_size = params.images.get(&self.image).unwrap().texture_descriptor.size;
+        let image_size = params.images.get(&handle_image).unwrap().texture_descriptor.size;
         // w & h are the world-space size of the sprite.
         let w = (image_size.width  as f32) / self.pixels_per_metre;
         let h = (image_size.height as f32) / self.pixels_per_metre;
 
         return Sprite3dBundle {
-            sprite_3d: Sprite3d {
-                texture_atlas: None,
-                texture_atlas_keys: None,
-            },
+            sprite_3d: Sprite3d::default(),
             mesh: {
                 let pivot = self.pivot.unwrap_or(Vec2::new(0.5, 0.5));
 
@@ -287,19 +321,22 @@ impl Sprite3dBuilder {
             // (possibly look into a bool in Sprite3dBuilder to manually disable caching for an individual sprite?)
             material: {
                 let mat_key = MatKey {
-                    image: self.image.clone(),
+                    image: handle_image.clone(),
                     alpha_mode: HashableAlphaMode(self.alpha_mode),
                     unlit: self.unlit,
                     emissive: reduce_colour(self.emissive),
+                    flip_x: false,
+                    flip_y: false,
                 };
 
                 MeshMaterial3d(if let Some(material) = params.caches.material_cache.get(&mat_key) { material.clone() }
                 else {
-                    let material = params.materials.add(material(self.image.clone(), self.alpha_mode, self.unlit, self.emissive));
+                    let material = params.materials.add(material(handle_image.clone(), self.alpha_mode, self.unlit, self.emissive));
                     params.caches.material_cache.insert(mat_key, material.clone());
                     material
                 })
             },
+            sprite: Sprite::default(),
         }
     }
 
@@ -307,10 +344,11 @@ impl Sprite3dBuilder {
     pub fn bundle_with_atlas(
         self,
         params: &mut Sprite3dParams,
+        handle_image: Handle<Image>,
         atlas: TextureAtlas,
     ) -> Sprite3dBundle {
         let atlas_layout = params.atlas_layouts.get(&atlas.layout).unwrap();
-        let image = params.images.get(&self.image).unwrap();
+        let image = params.images.get(&handle_image).unwrap();
         let image_size = image.texture_descriptor.size;
 
         let pivot = self.pivot.unwrap_or(Vec2::new(0.5, 0.5));
@@ -379,22 +417,31 @@ impl Sprite3dBuilder {
             mesh: Mesh3d(params.caches.mesh_cache.get(&mesh_keys[atlas.index]).unwrap().clone()),
             material: {
                 let mat_key = MatKey {
-                    image: self.image.clone(),
+                    image: handle_image.clone(),
                     alpha_mode: HashableAlphaMode(self.alpha_mode),
                     unlit: self.unlit,
                     emissive: reduce_colour(self.emissive),
+                    flip_x: false,
+                    flip_y: false,
                 };
                 MeshMaterial3d(if let Some(material) = params.caches.material_cache.get(&mat_key) { material.clone() }
                 else {
-                    let material = params.materials.add(material(self.image.clone(), self.alpha_mode, self.unlit, self.emissive));
+                    let material = params.materials.add(material(handle_image.clone(), self.alpha_mode, self.unlit, self.emissive));
                     params.caches.material_cache.insert(mat_key, material.clone());
                     material
                 })
             },
             sprite_3d: Sprite3d {
-                texture_atlas: Some(atlas),
                 texture_atlas_keys: Some(mesh_keys),
+                alpha_mode: self.alpha_mode,
+                unlit: self.unlit,
+                emissive: self.emissive,
             },
+            sprite: Sprite {
+                image: handle_image.clone(),
+                texture_atlas: Some(atlas),
+                ..default()
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy::render::{ mesh::*, render_resource::*, render_asset::RenderAssetUsages};
+use bevy::render::{mesh::*, render_asset::RenderAssetUsages, render_resource::*};
 use bevy::utils::HashMap;
 use std::hash::Hash;
 
@@ -9,7 +9,7 @@ pub struct Sprite3dPlugin;
 impl Plugin for Sprite3dPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<Sprite3dCaches>();
-        app.add_systems(PostUpdate, (handle_texture_atlases, handle_images));
+        app.add_systems(PostUpdate, (bundle_builder, (handle_texture_atlases, handle_images).after(bundle_builder)));
     }
 }
 
@@ -17,20 +17,6 @@ impl Plugin for Sprite3dPlugin {
 // sizes are multiplied by this, then cast to ints to query the mesh hashmap.
 const MESH_CACHE_GRANULARITY: f32 = 1000.;
 
-use std::marker::PhantomData;
-use bevy::ecs::system::SystemParam;
-
-// everything needed to register a sprite, passed in one go.
-#[derive(SystemParam)]
-pub struct Sprite3dParams<'w, 's> {
-    pub meshes        : ResMut<'w, Assets<Mesh>>,
-    pub materials     : ResMut<'w, Assets<StandardMaterial>>,
-    pub images        : ResMut<'w, Assets<Image>>,
-    pub atlas_layouts : ResMut<'w, Assets<TextureAtlasLayout>>,
-    pub caches        : ResMut<'w, Sprite3dCaches>,
-    #[system_param(ignore)]
-    marker: PhantomData<&'s usize>,
-}
 
 #[derive(Eq, Hash, PartialEq)]
 pub struct MatKey {
@@ -88,13 +74,135 @@ impl Default for Sprite3dCaches {
     }
 }
 
+fn bundle_builder(
+    mut commands: Commands,
+    images: Res<Assets<Image>>,
+    mut caches: ResMut<Sprite3dCaches>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    atlas_layouts: ResMut<Assets<TextureAtlasLayout>>,
+    mut query: Query<(&mut Sprite3d, &mut Mesh3d, &mut MeshMaterial3d<StandardMaterial>, &Sprite, Entity), With<Sprite3dBuilder>>,
+) {
+    for (mut sprite3d, mut mesh, mut mat, sprite, e) in query.iter_mut() {
+        // get image dimensions
+        let image_size = images.get(&sprite.image).unwrap().texture_descriptor.size;
+        // w & h are the world-space size of the sprite.
+        let w = (image_size.width as f32) / sprite3d.pixels_per_metre;
+        let h = (image_size.height as f32) / sprite3d.pixels_per_metre;
+        let pivot = sprite3d.pivot.unwrap_or(Vec2::new(0.5, 0.5));
 
+        if let Some(atlas) = &sprite.texture_atlas {
+            let atlas_layout = atlas_layouts.get(&atlas.layout).unwrap();
+
+            // cache all the meshes for the atlas (if they haven't been already)
+            // so that we can change the index later and not have to re-create the mesh.
+
+            for i in 0..atlas_layout.textures.len() {
+                let rect = atlas_layout.textures[i];
+
+                let w = rect.width() as f32 / sprite3d.pixels_per_metre;
+                let h = rect.height() as f32 / sprite3d.pixels_per_metre;
+
+                let frac_rect = bevy::math::Rect {
+                    min: Vec2::new(rect.min.x as f32 / (image_size.width as f32),
+                                   rect.min.y as f32 / (image_size.height as f32)),
+
+                    max: Vec2::new(rect.max.x as f32 / (image_size.width as f32),
+                                   rect.max.y as f32 / (image_size.height as f32)),
+                };
+
+                let mut rect_pivot = pivot;
+
+                // scale pivot to be relative to the rect within the atlas.
+                rect_pivot.x *= frac_rect.width();
+                rect_pivot.y *= frac_rect.height();
+                rect_pivot += frac_rect.min;
+
+
+                let mesh_key = [(w * MESH_CACHE_GRANULARITY) as u32,
+                    (h * MESH_CACHE_GRANULARITY) as u32,
+                    (rect_pivot.x * MESH_CACHE_GRANULARITY) as u32,
+                    (rect_pivot.y * MESH_CACHE_GRANULARITY) as u32,
+                    sprite3d.double_sided as u32,
+                    (frac_rect.min.x * MESH_CACHE_GRANULARITY) as u32,
+                    (frac_rect.min.y * MESH_CACHE_GRANULARITY) as u32,
+                    (frac_rect.max.x * MESH_CACHE_GRANULARITY) as u32,
+                    (frac_rect.max.y * MESH_CACHE_GRANULARITY) as u32];
+
+                sprite3d.texture_atlas_keys.push(mesh_key);
+
+                // if we don't have a mesh in the cache, create it.
+                if !caches.mesh_cache.contains_key(&mesh_key) {
+                    let mut mesh = quad(w, h, Some(pivot), sprite3d.double_sided);
+                    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vec![
+                        [frac_rect.min.x, frac_rect.max.y],
+                        [frac_rect.max.x, frac_rect.max.y],
+                        [frac_rect.min.x, frac_rect.min.y],
+                        [frac_rect.max.x, frac_rect.min.y],
+                        [frac_rect.min.x, frac_rect.max.y],
+                        [frac_rect.max.x, frac_rect.max.y],
+                        [frac_rect.min.x, frac_rect.min.y],
+                        [frac_rect.max.x, frac_rect.min.y],
+                    ]);
+                    let mesh_h = meshes.add(mesh);
+                    caches.mesh_cache.insert(mesh_key, mesh_h);
+                }
+            }
+        } else { // No texture atlas
+            let mesh_key = [(w * MESH_CACHE_GRANULARITY) as u32,
+                (h * MESH_CACHE_GRANULARITY) as u32,
+                (pivot.x * MESH_CACHE_GRANULARITY) as u32,
+                (pivot.y * MESH_CACHE_GRANULARITY) as u32,
+                sprite3d.double_sided as u32,
+                0, 0, 0, 0
+            ];
+            sprite3d.texture_atlas_keys.push(mesh_key);
+        }
+
+        *mesh = {
+            let mesh_key = if let Some(atlas) = &sprite.texture_atlas {
+                sprite3d.texture_atlas_keys[atlas.index]
+            } else {
+                *sprite3d.texture_atlas_keys.first().unwrap()
+            };
+            // if we have a mesh in the cache, use it.
+            // (greatly reduces number of unique meshes for tilemaps, etc.)
+            Mesh3d(if let Some(mesh) = caches.mesh_cache.get(&mesh_key) { mesh.clone() } else { // otherwise, create a new mesh and cache it.
+                let mesh = meshes.add(quad(w, h, sprite3d.pivot, sprite3d.double_sided));
+                caches.mesh_cache.insert(mesh_key, mesh.clone());
+                mesh
+            })
+        };
+
+        // likewise for material, use the existing if the image is already cached.
+        // (possibly look into a bool in Sprite3dBuilder to manually disable caching for an individual sprite?)
+        *mat = {
+            let mat_key = MatKey {
+                image: sprite.image.clone(),
+                alpha_mode: HashableAlphaMode(sprite3d.alpha_mode),
+                unlit: sprite3d.unlit,
+                emissive: reduce_colour(sprite3d.emissive),
+                flip_x: sprite.flip_x,
+                flip_y: sprite.flip_y,
+            };
+            MeshMaterial3d(if let Some(material) = caches.material_cache.get(&mat_key) { material.clone() } else {
+                let material = materials.add(build_material(sprite.image.clone(), sprite3d.alpha_mode, sprite3d.unlit, sprite3d.emissive, sprite.flip_x, sprite.flip_y));
+                caches.material_cache.insert(mat_key, material.clone());
+                material
+            })
+        };
+
+        commands.entity(e).remove::<Sprite3dBuilder>();
+    }
+}
+
+// Update the mesh when sprite image change
 fn handle_images(
     mut caches: ResMut<Sprite3dCaches>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut query: Query<(&mut MeshMaterial3d<StandardMaterial>, &Sprite, &Sprite3d), Changed<Sprite>>) {
-    for (mut mesh, sprite, sprite_3d) in query.iter_mut() {
-        let current_mat = &mesh.0;
+    for (mut mesh_mat, sprite, sprite_3d) in query.iter_mut() {
+        let current_mat = &mesh_mat.0;
         let mat_key = MatKey {
             image: sprite.image.clone(),
             alpha_mode: HashableAlphaMode(sprite_3d.alpha_mode),
@@ -104,18 +212,17 @@ fn handle_images(
             flip_y: sprite.flip_y,
         };
         let mat = if let Some(material) = caches.material_cache.get(&mat_key) { material.clone() } else {
-            let mut material = material(sprite.image.clone(), sprite_3d.alpha_mode, sprite_3d.unlit, sprite_3d.emissive);
-            material.flip(mat_key.flip_x, mat_key.flip_y);
-            let material = materials.add(material);
+            let material = materials.add(build_material(sprite.image.clone(), sprite_3d.alpha_mode, sprite_3d.unlit, sprite_3d.emissive, sprite.flip_x, sprite.flip_y));
             caches.material_cache.insert(mat_key, material.clone());
             material
         };
 
         if *current_mat != mat {
-            *mesh = MeshMaterial3d(mat);
+            *mesh_mat = MeshMaterial3d(mat);
         }
     }
 }
+
 
 // Update the mesh of a Sprite3d with an atlas sprite when its index changes.
 fn handle_texture_atlases(
@@ -126,11 +233,7 @@ fn handle_texture_atlases(
         let Some(texture_atlas) = &sprite.texture_atlas else {
             continue;
         };
-        let Some(mesh_keys) = &sprite_3d.texture_atlas_keys else {
-            continue;
-        };
-
-        **mesh = caches.mesh_cache.get(&mesh_keys[texture_atlas.index]).unwrap().clone();
+        **mesh = caches.mesh_cache.get(&sprite_3d.texture_atlas_keys[texture_atlas.index]).unwrap().clone();
     }
 }
 
@@ -183,8 +286,8 @@ fn quad(w: f32, h: f32, pivot: Option<Vec2>, double_sided: bool) -> Mesh {
 
 
 // generate a StandardMaterial useful for rendering a sprite
-fn material(image: Handle<Image>, alpha_mode: AlphaMode, unlit: bool, emissive: LinearRgba) -> StandardMaterial {
-    StandardMaterial {
+fn build_material(image: Handle<Image>, alpha_mode: AlphaMode, unlit: bool, emissive: LinearRgba, flip_x: bool, flip_y: bool) -> StandardMaterial {
+    let mut mat = StandardMaterial {
         base_color_texture: Some(image),
         cull_mode: Some(Face::Back),
         alpha_mode,
@@ -194,17 +297,38 @@ fn material(image: Handle<Image>, alpha_mode: AlphaMode, unlit: bool, emissive: 
         emissive,
 
         ..Default::default()
-    }
+    };
+    mat.flip(flip_x, flip_y);
+    mat
 }
 
 
+#[derive(Component, Default)]
+struct Sprite3dBuilder;
 
+/// Represents a 3D sprite. May store texture atlas data -- note that modifying
+/// `texture_atlas` and `texture_atlas_keys` on an already spawned sprite may
+/// cause buggy behavior.
+#[derive(Component)]
+#[require(Transform, Mesh3d, MeshMaterial3d<StandardMaterial>, Sprite3dBuilder)]
+pub struct Sprite3d {
+    pub texture_atlas_keys: Vec<[u32; 9]>,
 
-/// A precursor struct for a sprite. Set necessary parameters manually, use
-/// `..default()` for others, then call `bundle()` to to get a bundle
-/// that can be spawned into the world.
-pub struct Sprite3dBuilder {
-    // TODO: ability to specify exact size, with None scaled by image's ratio and other.
+    /// The sprite's alpha mode.
+    ///
+    /// - `Mask(0.5)` (default) only allows fully opaque or fully transparent pixels
+    ///   (cutoff at `0.5`).
+    /// - `Blend` allows partially transparent pixels (slightly more expensive).
+    /// - Use any other value to achieve desired blending effect.
+    pub alpha_mode: AlphaMode,
+
+    /// Whether the sprite should be rendered as unlit.
+    /// `false` (default) allows for lighting.
+    pub unlit: bool,
+
+    /// An emissive colour, if the sprite should emit light.
+    /// `LinearRgba::Black` (default) does nothing.
+    pub emissive: LinearRgba,
 
     /// the number of pixels per metre of the sprite, assuming a `Transform::scale` of 1.0.
     pub pixels_per_metre: f32,
@@ -217,231 +341,22 @@ pub struct Sprite3dBuilder {
     ///   (though you can go out of bounds without issue)
     pub pivot: Option<Vec2>,
 
-    /// The sprite's alpha mode.
-    ///
-    /// - `Mask(0.5)` (default) only allows fully opaque or fully transparent pixels
-    ///   (cutoff at `0.5`).
-    /// - `Blend` allows partially transparent pixels (slightly more expensive).
-    /// - Use any other value to achieve desired blending effect.
-    pub alpha_mode: AlphaMode,
-
-    /// Whether the sprite should be rendered as unlit.
-    /// `false` (default) allows for lighting.
-    pub unlit: bool,
-
     /// Whether the sprite should be rendered as double-sided.
     /// `true` (default) adds a second set of indices, describing the same tris
     /// in reverse order.
     pub double_sided: bool,
-
-    /// An emissive colour, if the sprite should emit light.
-    /// `LinearRgba::Black` (default) does nothing.
-    pub emissive: LinearRgba,
 }
 
-impl Default for Sprite3dBuilder {
+impl Default for Sprite3d {
     fn default() -> Self {
         Self {
+            texture_atlas_keys: Vec::new(),
             pixels_per_metre: 100.,
             pivot: None,
             alpha_mode: DEFAULT_ALPHA_MODE,
             unlit: false,
             double_sided: true,
             emissive: LinearRgba::BLACK,
-        }
-    }
-}
-
-
-/// Represents a 3D sprite. May store texture atlas data -- note that modifying
-/// `texture_atlas` and `texture_atlas_keys` on an already spawned sprite may
-/// cause buggy behavior.
-#[derive(Component, Default)]
-#[require(Transform, Mesh3d, Sprite)]
-pub struct Sprite3d {
-    pub texture_atlas_keys: Option<Vec<[u32; 9]>>,
-
-    /// The sprite's alpha mode.
-    ///
-    /// - `Mask(0.5)` (default) only allows fully opaque or fully transparent pixels
-    ///   (cutoff at `0.5`).
-    /// - `Blend` allows partially transparent pixels (slightly more expensive).
-    /// - Use any other value to achieve desired blending effect.
-    pub alpha_mode: AlphaMode,
-
-    /// Whether the sprite should be rendered as unlit.
-    /// `false` (default) allows for lighting.
-    pub unlit: bool,
-
-    /// An emissive colour, if the sprite should emit light.
-    /// `LinearRgba::Black` (default) does nothing.
-    pub emissive: LinearRgba,
-}
-
-#[derive(Bundle)]
-pub struct Sprite3dBundle {
-    pub sprite: Sprite,
-    pub sprite_3d: Sprite3d,
-    pub mesh: Mesh3d,
-    pub material: MeshMaterial3d<StandardMaterial>,
-}
-
-impl Sprite3dBuilder {
-    /// creates a bundle of components
-    pub fn bundle(self, params: &mut Sprite3dParams, handle_image: Handle<Image>) -> Sprite3dBundle {
-        // get image dimensions
-        let image_size = params.images.get(&handle_image).unwrap().texture_descriptor.size;
-        // w & h are the world-space size of the sprite.
-        let w = (image_size.width  as f32) / self.pixels_per_metre;
-        let h = (image_size.height as f32) / self.pixels_per_metre;
-
-        return Sprite3dBundle {
-            sprite_3d: Sprite3d::default(),
-            mesh: {
-                let pivot = self.pivot.unwrap_or(Vec2::new(0.5, 0.5));
-
-                let mesh_key = [(w * MESH_CACHE_GRANULARITY) as u32,
-                                (h * MESH_CACHE_GRANULARITY) as u32,
-                                (pivot.x * MESH_CACHE_GRANULARITY) as u32,
-                                (pivot.y * MESH_CACHE_GRANULARITY) as u32,
-                                self.double_sided as u32,
-                                0, 0, 0, 0
-                                ];
-
-                // if we have a mesh in the cache, use it.
-                // (greatly reduces number of unique meshes for tilemaps, etc.)
-                Mesh3d(if let Some(mesh) = params.caches.mesh_cache.get(&mesh_key) { mesh.clone() }
-                else { // otherwise, create a new mesh and cache it.
-                    let mesh = params.meshes.add(quad( w, h, self.pivot, self.double_sided ));
-                    params.caches.mesh_cache.insert(mesh_key, mesh.clone());
-                    mesh
-                })
-            },
-            // likewise for material, use the existing if the image is already cached.
-            // (possibly look into a bool in Sprite3dBuilder to manually disable caching for an individual sprite?)
-            material: {
-                let mat_key = MatKey {
-                    image: handle_image.clone(),
-                    alpha_mode: HashableAlphaMode(self.alpha_mode),
-                    unlit: self.unlit,
-                    emissive: reduce_colour(self.emissive),
-                    flip_x: false,
-                    flip_y: false,
-                };
-
-                MeshMaterial3d(if let Some(material) = params.caches.material_cache.get(&mat_key) { material.clone() }
-                else {
-                    let material = params.materials.add(material(handle_image.clone(), self.alpha_mode, self.unlit, self.emissive));
-                    params.caches.material_cache.insert(mat_key, material.clone());
-                    material
-                })
-            },
-            sprite: Sprite::default(),
-        }
-    }
-
-    /// creates a bundle of components with support for texture atlases
-    pub fn bundle_with_atlas(
-        self,
-        params: &mut Sprite3dParams,
-        handle_image: Handle<Image>,
-        atlas: TextureAtlas,
-    ) -> Sprite3dBundle {
-        let atlas_layout = params.atlas_layouts.get(&atlas.layout).unwrap();
-        let image = params.images.get(&handle_image).unwrap();
-        let image_size = image.texture_descriptor.size;
-
-        let pivot = self.pivot.unwrap_or(Vec2::new(0.5, 0.5));
-        // cache all the meshes for the atlas (if they haven't been already)
-        // so that we can change the index later and not have to re-create the mesh.
-
-        // store all lookup keys in a vec so we later know which meshes to retrieve.
-        let mut mesh_keys = Vec::new();
-
-
-        for i in 0..atlas_layout.textures.len() {
-
-            let rect = atlas_layout.textures[i];
-
-            let w = rect.width() as f32 / self.pixels_per_metre;
-            let h = rect.height() as f32 / self.pixels_per_metre;
-
-            let frac_rect = bevy::math::Rect {
-                min: Vec2::new(rect.min.x as f32 / (image_size.width as f32),
-                               rect.min.y as f32 / (image_size.height as f32)),
-
-                max: Vec2::new(rect.max.x as f32 / (image_size.width as f32),
-                               rect.max.y as f32 / (image_size.height as f32)),
-            };
-
-            let mut rect_pivot = pivot;
-
-            // scale pivot to be relative to the rect within the atlas.
-            rect_pivot.x *= frac_rect.width();
-            rect_pivot.y *= frac_rect.height();
-            rect_pivot += frac_rect.min;
-
-
-            let mesh_key = [(w * MESH_CACHE_GRANULARITY) as u32,
-                            (h * MESH_CACHE_GRANULARITY) as u32,
-                            (rect_pivot.x * MESH_CACHE_GRANULARITY) as u32,
-                            (rect_pivot.y * MESH_CACHE_GRANULARITY) as u32,
-                            self.double_sided as u32,
-                            (frac_rect.min.x * MESH_CACHE_GRANULARITY) as u32,
-                            (frac_rect.min.y * MESH_CACHE_GRANULARITY) as u32,
-                            (frac_rect.max.x * MESH_CACHE_GRANULARITY) as u32,
-                            (frac_rect.max.y * MESH_CACHE_GRANULARITY) as u32];
-
-            mesh_keys.push(mesh_key);
-
-            // if we don't have a mesh in the cache, create it.
-            if !params.caches.mesh_cache.contains_key(&mesh_key) {
-                let mut mesh = quad( w, h, Some(pivot), self.double_sided );
-                mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vec![
-                    [frac_rect.min.x, frac_rect.max.y],
-                    [frac_rect.max.x, frac_rect.max.y],
-                    [frac_rect.min.x, frac_rect.min.y],
-                    [frac_rect.max.x, frac_rect.min.y],
-
-                    [frac_rect.min.x, frac_rect.max.y],
-                    [frac_rect.max.x, frac_rect.max.y],
-                    [frac_rect.min.x, frac_rect.min.y],
-                    [frac_rect.max.x, frac_rect.min.y],
-                ]);
-                let mesh_h = params.meshes.add(mesh);
-                params.caches.mesh_cache.insert(mesh_key, mesh_h);
-            }
-        }
-
-        return Sprite3dBundle {
-            mesh: Mesh3d(params.caches.mesh_cache.get(&mesh_keys[atlas.index]).unwrap().clone()),
-            material: {
-                let mat_key = MatKey {
-                    image: handle_image.clone(),
-                    alpha_mode: HashableAlphaMode(self.alpha_mode),
-                    unlit: self.unlit,
-                    emissive: reduce_colour(self.emissive),
-                    flip_x: false,
-                    flip_y: false,
-                };
-                MeshMaterial3d(if let Some(material) = params.caches.material_cache.get(&mat_key) { material.clone() }
-                else {
-                    let material = params.materials.add(material(handle_image.clone(), self.alpha_mode, self.unlit, self.emissive));
-                    params.caches.material_cache.insert(mat_key, material.clone());
-                    material
-                })
-            },
-            sprite_3d: Sprite3d {
-                texture_atlas_keys: Some(mesh_keys),
-                alpha_mode: self.alpha_mode,
-                unlit: self.unlit,
-                emissive: self.emissive,
-            },
-            sprite: Sprite {
-                image: handle_image.clone(),
-                texture_atlas: Some(atlas),
-                ..default()
-            }
         }
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,4 @@
 pub use crate::{
     Sprite3d,
-    Sprite3dBuilder,
-    Sprite3dBundle,
-    Sprite3dParams,
     Sprite3dPlugin,
 };


### PR DESCRIPTION
This PR aims to make this plugin more easier to use in Bevy way and help code can be reusable between 2d and 3d.

### Usage change

* Spawning
  * old
    ```rust
    commands.spawn(Sprite3dBuilder {
            image: assets.image.clone(),
            pixels_per_metre: 32.,
            alpha_mode: AlphaMode::Blend,
            unlit: true,
            // pivot: Some(Vec2::new(0.5, 0.5)),
            ..default()
    }.bundle_with_atlas(&mut sprite_params, texture_atlas))
    .insert(AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)));
    ```

  * new
    ```rust
    commands.spawn((
        Sprite { image: assets.image.clone(), texture_atlas: Some(texture_atlas), ..default() },
        Sprite3d {
            pixels_per_metre: 32.,
            alpha_mode: AlphaMode::Blend,
            unlit: true,
            // pivot: Some(Vec2::new(0.5, 0.5)),
            ..default()
        },
        AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)),
    ));
    ```

* Animate sprite sheet:
  * old
    ```rust
    // Need to call `Sprite3d`, cannot reuse in 2d code
    fn animate_sprite(
        time: Res<Time>,
        mut query: Query<(&mut AnimationTimer, &mut Sprite3d)>,
    ) {
        for (mut timer, mut sprite_3d) in query.iter_mut() {
            timer.tick(time.delta());
            if timer.just_finished() {
                let length = sprite_3d.texture_atlas_keys.as_ref().unwrap().len();
                let atlas = sprite_3d.texture_atlas.as_mut().unwrap();
                atlas.index = (atlas.index + 1) % length;
            }
        }
    }
    ```

  * new
    ```rust
    // Same with 2d code for animate
    fn animate_sprite(
        time: Res<Time>,
        atlases: Res<Assets<TextureAtlasLayout>>,
        mut query: Query<(&mut AnimationTimer, &mut Sprite)>,
    ) {
        for (mut timer, mut sprite) in query.iter_mut() {
            timer.tick(time.delta());
            if timer.just_finished() {
                let atlas = sprite.texture_atlas.as_mut().unwrap();
                if let Some(layouts) = atlases.get(&atlas.layout) {
                    atlas.index = (atlas.index + 1) % layouts.textures.len();
                }
            }
        }
    }
    ```

* Easy to change spritesheet. Sprite can be flipped too:
  ```rust
  // Same code can be used for both 2d and 3d
  fn walk_left (
      spritesheets: Res<MySpriteSheets>
      mut query: Query<&mut Sprite>,
  ) {
      for mut sprite in query.iter_mut() {
          sprite.image = spritesheets.walk_right.clone();
          sprite.flip_x = true;
      }
  }
  ```

### Code change

* Replace `bundle()` and `bundle_and_atlas()` by system `bundle_builder`.
* Attributes in `Sprite3dBuilder` are moved to `Sprite3d`.
* `Sprite3dBuilder` now is used as a marker for entity that is not doing `bundle_builder`. After that, this component will be removed out of entity.
* Add system `handle_image` to handle `Sprite` image change.
* `Sprite3dParams` and `Sprite3dBundle` are unused and removed.