### PR TITLE
Lazy Loading with Hooks and Custom Material support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["gamedev", "bevy", "sprite", "3d"]
 [dependencies.bevy]
 version = "0.18.0"
 default-features = false
-features = ["bevy_asset", "bevy_pbr", "bevy_sprite", "png", "std"]
+features = ["bevy_asset", "bevy_pbr", "bevy_sprite", "bevy_log", "png", "std"]
 
 [dev-dependencies]
 bevy.version = "0.18.0" # (include default features when running examples)

--- a/FORK_FEATURES.md
+++ b/FORK_FEATURES.md
@@ -1,0 +1,88 @@
+# Fork Features
+
+This fork of [bevy_sprite3d](https://github.com/FraserLee/bevy_sprite3d) adds the following features on top of the original library:
+
+## 1. Async Asset Loading (No Panic on Missing Assets)
+
+The original library panics with `.unwrap()` if a sprite's image or texture atlas layout isn't loaded when the sprite is spawned. This fork defers sprite construction until assets are ready.
+
+**How it works:**
+- When a `Sprite3d` is spawned but its assets aren't loaded yet, the entity is added to a `WaitingSprites` resource
+- An async task is spawned using `IoTaskPool` to wait for the asset to load
+- The `finalize_waiting_sprites` system polls these tasks and completes sprite construction once assets are ready
+- If asset loading fails, a warning is logged instead of panicking
+
+**Benefits:**
+- Sprites can be spawned at any time without pre-loading assets
+- No need for complex state management to ensure assets are ready
+- Graceful error handling with warnings instead of panics
+
+## 2. User-Provided Material Support
+
+The original library always creates and caches its own `StandardMaterial`. This fork detects when a user provides their own material and preserves it.
+
+**How it works:**
+- An `on_insert` component hook detects if a `MeshMaterial3d<StandardMaterial>` exists before `Sprite3d` is inserted
+- If found, the entity is marked with `Sprite3dUserMaterial`
+- For user materials, only texture-related fields are updated:
+  - `base_color_texture` (always set to the sprite's image)
+  - `alpha_mode`, `unlit`, `emissive` (only if non-default on `Sprite3d`)
+  - `flip_x`, `flip_y` (if set on the `Sprite`)
+- The user retains control over: `base_color`, `roughness`, `reflectance`, `metallic`, all texture maps, `cull_mode`, etc.
+
+**Usage:**
+```rust
+commands.spawn((
+    MeshMaterial3d(materials.add(StandardMaterial {
+        base_color: Color::srgb(1.0, 0.5, 0.5),
+        metallic: 0.8,
+        ..default()
+    })),
+    Sprite3d::default(),
+    Sprite {
+        image: asset_server.load("sprite.png"),
+        ..default()
+    },
+));
+```
+
+## 3. Sprite.color Tinting Support
+
+The original library ignores the `Sprite.color` field. This fork uses it to tint cached materials.
+
+**How it works:**
+- The `base_color` is included in `MatKey` for material caching
+- When creating a new cached material, `base_color` is set from `Sprite.color`
+- Materials with different colors are cached separately
+
+**Usage:**
+```rust
+commands.spawn((
+    Sprite3d::default(),
+    Sprite {
+        image: asset_server.load("sprite.png"),
+        color: Color::srgb(1.0, 0.0, 0.0), // Red tint
+        ..default()
+    },
+));
+```
+
+**Note:** For user-provided materials, `Sprite.color` is ignored and you control `base_color` directly on your material.
+
+---
+
+## API Additions
+
+### `Sprite3dUserMaterial` (Component)
+
+A marker component automatically added when you provide a material before `Sprite3d`. You can query for this to detect which sprites use custom materials:
+
+```rust
+fn my_system(query: Query<Entity, With<Sprite3dUserMaterial>>) {
+    for entity in query.iter() {
+        // This entity has a user-provided material
+    }
+}
+```
+
+This component is exported in the prelude.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,1 +1,1 @@
-pub use crate::{Sprite3d, Sprite3dPlugin};
+pub use crate::{Sprite3d, Sprite3dPlugin, Sprite3dUserMaterial};

--- a/tests/fork_features.rs
+++ b/tests/fork_features.rs
@@ -1,0 +1,144 @@
+//! Integration tests for fork-specific features:
+//! - Async asset loading (deferred construction)
+//! - User-provided material preservation
+//! - Sprite.color tinting support
+//!
+//! These tests verify the additional functionality added by this fork.
+
+use bevy::prelude::*;
+use bevy_sprite3d::prelude::*;
+
+/// Test that Sprite3dUserMaterial marker is added when user provides material first.
+#[test]
+fn user_material_detection()
+{
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+       .add_plugins(AssetPlugin::default())
+       .init_asset::<Image>()
+       .init_asset::<Mesh>()
+       .init_asset::<StandardMaterial>()
+       .init_asset::<TextureAtlasLayout>()
+       .add_plugins(Sprite3dPlugin);
+
+    let mut materials = app.world_mut().resource_mut::<Assets<StandardMaterial>>();
+    let user_mat =
+        materials.add(StandardMaterial { base_color: Color::srgb(1.0, 0.0, 0.0), ..default() });
+
+    let mut images = app.world_mut().resource_mut::<Assets<Image>>();
+    let image = images.add(Image::default());
+
+    // Spawn with user material BEFORE Sprite3d
+    let entity =
+        app.world_mut()
+           .spawn((MeshMaterial3d(user_mat), Sprite3d::default(), Sprite { image, ..default() }))
+           .id();
+
+    // Run systems
+    app.update();
+
+    // Check that Sprite3dUserMaterial marker was added
+    assert!(app.world().get::<Sprite3dUserMaterial>(entity).is_some(),
+            "Sprite3dUserMaterial should be added when user provides material before Sprite3d");
+}
+
+/// Test that no Sprite3dUserMaterial marker is added when library creates material.
+#[test]
+fn no_user_material_when_library_creates()
+{
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+       .add_plugins(AssetPlugin::default())
+       .init_asset::<Image>()
+       .init_asset::<Mesh>()
+       .init_asset::<StandardMaterial>()
+       .init_asset::<TextureAtlasLayout>()
+       .add_plugins(Sprite3dPlugin);
+
+    let mut images = app.world_mut().resource_mut::<Assets<Image>>();
+    let image = images.add(Image::default());
+
+    // Spawn without user material
+    let entity = app.world_mut().spawn((Sprite3d::default(), Sprite { image, ..default() })).id();
+
+    // Run systems
+    app.update();
+
+    // Check that Sprite3dUserMaterial marker was NOT added
+    assert!(app.world().get::<Sprite3dUserMaterial>(entity).is_none(),
+            "Sprite3dUserMaterial should NOT be added when library creates material");
+}
+
+/// Test that MatKey includes base_color for proper caching of tinted sprites.
+#[test]
+fn sprite_color_creates_different_materials()
+{
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+       .add_plugins(AssetPlugin::default())
+       .init_asset::<Image>()
+       .init_asset::<Mesh>()
+       .init_asset::<StandardMaterial>()
+       .init_asset::<TextureAtlasLayout>()
+       .add_plugins(Sprite3dPlugin);
+
+    let mut images = app.world_mut().resource_mut::<Assets<Image>>();
+    let image = images.add(Image::default());
+
+    // Spawn two sprites with same image but different colors
+    let entity1 = app.world_mut()
+                     .spawn((Sprite3d::default(),
+                             Sprite { image: image.clone(),
+                                      color: Color::srgb(1.0, 0.0, 0.0), // Red
+                                      ..default() }))
+                     .id();
+
+    let entity2 = app.world_mut()
+                     .spawn((Sprite3d::default(),
+                             Sprite { image,
+                                      color: Color::srgb(0.0, 1.0, 0.0), // Green
+                                      ..default() }))
+                     .id();
+
+    // Run systems
+    app.update();
+
+    // Get material handles
+    let mat1 = app.world().get::<MeshMaterial3d<StandardMaterial>>(entity1).map(|m| m.0.clone());
+    let mat2 = app.world().get::<MeshMaterial3d<StandardMaterial>>(entity2).map(|m| m.0.clone());
+
+    assert!(mat1.is_some(), "Entity 1 should have a material");
+    assert!(mat2.is_some(), "Entity 2 should have a material");
+
+    // Materials should be different because colors are different
+    assert_ne!(mat1.unwrap(),
+               mat2.unwrap(),
+               "Sprites with different colors should have different cached materials");
+}
+
+/// Test that sprites with unloaded assets don't panic (deferred loading).
+#[test]
+fn deferred_loading_no_panic()
+{
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+       .add_plugins(AssetPlugin::default())
+       .init_asset::<Image>()
+       .init_asset::<Mesh>()
+       .init_asset::<StandardMaterial>()
+       .init_asset::<TextureAtlasLayout>()
+       .add_plugins(Sprite3dPlugin);
+
+    // Create an unloaded image handle (simulating asset not yet loaded)
+    let unloaded_handle: Handle<Image> = Handle::default();
+
+    // This should NOT panic - the sprite construction should be deferred
+    let _entity = app.world_mut()
+                     .spawn((Sprite3d::default(), Sprite { image: unloaded_handle, ..default() }))
+                     .id();
+
+    // Run systems - this would panic in the original implementation
+    app.update();
+
+    // If we get here without panicking, the test passes
+}


### PR DESCRIPTION
I was inspired by @vertesians pull request to fork Sprite3d and implement on top of it the same kind of lazy loading with hooks.

Additionally, I wanted to have the support to supply custom materials, or just set the color of a 3d Sprite as well quickly, so I added a more hybrid approach to the material handling: one can either provide a full Material in the bundle to finetune all sorts of settings, or just set Sprite.color.

I also expanded the caching with the color.

Now _I am sorry_, but before I even realized, I had _code formatted the files I touched_, and I have yet to come back to it and clean up a few repetititions. If this is really a problem, I can try to manually format it back before rustfmt kicked in.

I am perfectly aware, that his pull request might be a bit big, and not accepted, but as the other one inspired me to do this, maybe it can also inspire yet another take until such features come into the official crate.

I personally just needed these features already :) 